### PR TITLE
Feature/rework-plugin-loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1418,12 +1418,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_toml"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e68184169792863bfb6d8b5de8e15456ebf4302f28236f0ff1136591eb66541"
-
-[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1468,12 +1462,8 @@ dependencies = [
  "anyhow",
  "once_cell",
  "rust-embed",
- "serde",
- "serde_json",
- "serde_toml",
  "structopt",
  "tokio",
- "toml",
  "tracing",
  "tracing-subscriber",
  "wasi-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,8 @@ maintenance = { status = "actively-developed" }
 anyhow = "1.0.79"
 once_cell = "1.19.0"
 rust-embed = { version = "8.2.0", features = ["interpolate-folder-path"] }
-serde = "1.0.195"
-serde_json = "1.0.112"
-serde_toml = "0.0.1"
 structopt = "0.3.26"
 tokio = { version = "1.35.1", features = ["rt-multi-thread", "macros", "fs"] }
-toml = "0.8.8"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 wasi-common = "22.0.0"

--- a/src/bin/skycrane.rs
+++ b/src/bin/skycrane.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use skycrane::{apply, destroy, init, load_plugins, reconcile, Cli, Commands};
+use skycrane::{apply, destroy, init, load_plugin, reconcile, Cli, Commands};
 use structopt::StructOpt;
 use tracing::debug;
 use tracing_subscriber::EnvFilter;
@@ -20,7 +20,7 @@ async fn main() -> Result<()> {
 
     debug!("loading with opts: {:#?}", &opts);
 
-    let instances = load_plugins(opts.config_path.clone())
+    let plugin = load_plugin(opts.config_path.clone(), "hetzner") // TODO: Fix me, this should come from the starlark file.
         .await
         .with_context(|| {
             format!(
@@ -30,7 +30,7 @@ async fn main() -> Result<()> {
         })?;
 
     match opts.commands {
-        Commands::Init(_) => init(&opts, instances.first().unwrap().to_owned()).await?, // TODO: Fix me!
+        Commands::Init(_) => init(&opts, plugin).await?, // TODO: Fix me!
         Commands::Apply(_) => apply(&opts)?,
         Commands::Reconcile(_) => reconcile(&opts)?,
         Commands::Destroy(_) => destroy(&opts)?,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,8 +1,8 @@
-use crate::Cli;
+use crate::{Cli, WasmPlugin};
 use anyhow::Result;
-use wasmtime::Instance;
 
-pub async fn init(_opts: &Cli, _instance: Instance) -> Result<()> {
+pub async fn init(opts: &Cli, _plugin: WasmPlugin) -> Result<()> {
+    println!("{:?}", opts);
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,8 @@ mod commands;
 mod wasm;
 
 pub use commands::{apply, destroy, init, reconcile};
-pub use wasm::engine::init_plugins;
-pub use wasm::plugins::{load_plugins, WasmPlugin};
+pub use wasm::engine::init_plugin;
+pub use wasm::plugins::{load_plugin, WasmPlugin};
 
 use std::env;
 use std::path::PathBuf;
@@ -39,7 +39,10 @@ pub enum Commands {
 pub struct Apply {}
 
 #[derive(StructOpt, Clone, Debug)]
-pub struct Init {}
+pub struct Init {
+    #[structopt(parse(from_os_str), help = "Path to initialize")]
+    pub path: PathBuf,
+}
 
 #[derive(StructOpt, Clone, Debug)]
 pub struct Reconcile {}

--- a/src/wasm/engine.rs
+++ b/src/wasm/engine.rs
@@ -1,33 +1,30 @@
 use crate::WasmPlugin;
-use anyhow::{Context, Result};
+use anyhow::{Context, Ok, Result};
 use tracing::info;
 use wasi_common::sync::{add_to_linker, WasiCtxBuilder};
 use wasmtime::*;
 
-pub fn init_plugins(plugins: Vec<WasmPlugin>) -> Result<Vec<Instance>> {
-    let mut instances = Vec::new();
+pub fn init_plugin(plugin: &mut WasmPlugin) -> Result<()> {
     let engine = Engine::default();
     let mut linker = Linker::new(&engine);
     add_to_linker(&mut linker, |s| s).with_context(|| "Failed to add WASI to linker")?;
     let wasi_ctx = WasiCtxBuilder::new().inherit_stdio().inherit_env()?.build();
     let mut store = Store::new(&engine, wasi_ctx);
 
-    for plugin in plugins {
-        let module = Module::from_file(&engine, &plugin.path)?;
-        linker.module(&mut store, &plugin.name, &module)?;
-        let instance = linker.instantiate(&mut store, &module)?;
-        instance
-            .get_func(&mut store, "plugin-api#deserialize-config")
-            .unwrap();
+    let module = Module::from_file(&engine, &plugin.path)?;
+    linker.module(&mut store, &plugin.name, &module)?;
+    let instance = linker.instantiate(&mut store, &module)?;
+    instance
+        .get_func(&mut store, "plugin-api#deserialize-config")
+        .unwrap();
 
-        info!(
-            "Successfully validated: {} from: {}",
-            plugin.name,
-            plugin.path.display()
-        );
+    info!(
+        "Successfully validated: {} from: {}",
+        plugin.name,
+        plugin.path.display()
+    );
 
-        instances.push(instance);
-    }
+    plugin.instance = Some(instance);
 
-    Ok(instances)
+    Ok(())
 }


### PR DESCRIPTION
Instead of loading all the plugins in memory, which there are no use cases for currently, we load a single one.
Since we don't yet have the starlark module parsing, we're just going to use a hardcoded value to load the test plugin, hetzner.

Signed-off-by: Victor Palade <victor@cloudflavor.io>