### PR TITLE
plugins: update plugin call method.

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -4,13 +4,24 @@ use anyhow::Result;
 use std::path::Path;
 use tracing::info;
 
+// Loading phase
+// * parse all the files from the directory that was passed by the user.
+// * establish what plugin we need based on the module name and version
+// * instantiate the plugin from the plugin path e.g.: ~/.config/skycrane/plugins/
+// * send starlark config to wasi plugin
+// * wasi plugin parses the config, filters out only available functionality it
+//   has, ignores everything else. It's more than possible that the contents of
+//   the starlark file are mixed between functions that the rust CLI offers
+//   and functions that the WASI plugin offers. Evaluating a starlark file
+//   with functions that are not in globals, will panic.
+
 pub async fn init(opts: Init, config_path: impl AsRef<Path>) -> Result<()> {
     info!("Initializing new repository at {:?}", opts.path);
 
     let base = format!("{}/base.star", opts.path.display());
     let config = read_config(&base).await?;
-    let plugin = extract_plugin(config.as_str())?;
-    load(config_path, &plugin.name).await?;
+    let cloud_mod = extract_plugin(config.as_str())?;
+    let _ = load(config_path, &cloud_mod.name).await?;
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,10 +5,15 @@ mod wasm;
 pub use commands::init;
 pub use wasm::engine::init_plugin;
 pub use wasm::plugins::{load_plugin, WasmPlugin};
+use wasmtime::component::bindgen;
 
 use std::env;
 use std::path::PathBuf;
 use structopt::StructOpt;
+
+bindgen!({
+    path: "../skyforge/spec/wit",
+});
 
 #[derive(StructOpt, Clone, Debug)]
 pub struct Cli {

--- a/src/wasm/engine.rs
+++ b/src/wasm/engine.rs
@@ -1,33 +1,46 @@
-use crate::WasmPlugin;
-use anyhow::{Context, Ok, Result};
+use crate::{SkyforgeApi, WasmPlugin};
+use anyhow::Result;
 use tracing::info;
-use wasi_common::sync::{add_to_linker, WasiCtxBuilder};
-use wasmtime::*;
+use wasmtime::component::{Component, Linker};
+use wasmtime::{Engine, Store};
+use wasmtime_wasi::{ResourceTable, WasiCtx, WasiCtxBuilder, WasiView};
+
+struct MyState {
+    ctx: WasiCtx,
+    table: ResourceTable,
+}
+impl WasiView for MyState {
+    fn ctx(&mut self) -> &mut wasmtime_wasi::WasiCtx {
+        &mut self.ctx
+    }
+    fn table(&mut self) -> &mut ResourceTable {
+        &mut self.table
+    }
+}
 
 pub fn init_plugin(plugin: &mut WasmPlugin) -> Result<()> {
     let engine = Engine::default();
-    let mut linker = Linker::new(&engine);
-    add_to_linker(&mut linker, |s| s).with_context(|| "Failed to add WASI to linker")?;
-    info!("Added WASI to linker");
-    let wasi_ctx = WasiCtxBuilder::new().inherit_stdio().inherit_env()?.build();
-    let mut store = Store::new(&engine, wasi_ctx);
 
-    let module = Module::from_file(&engine, &plugin.path)?;
-    linker.module(&mut store, &plugin.name, &module)?;
-    let instance = linker.instantiate(&mut store, &module)?;
-    instance
-        .get_func(&mut store, "plugin-api#deserialize-config")
-        .ok_or(anyhow::anyhow!(
-            "Failed to find deserialize-config function"
-        ))?;
-
-    info!(
-        "Successfully validated: {} from: {}",
-        plugin.name,
-        plugin.path.display()
+    let mut store = Store::new(
+        &engine,
+        MyState {
+            // TODO: This should be configurable
+            ctx: WasiCtxBuilder::new()
+                .inherit_env()
+                .inherit_stdio()
+                .inherit_stdout()
+                .build(),
+            table: ResourceTable::default(),
+        },
     );
+    let component = Component::from_file(&engine, &plugin.path)?;
+    let mut linker = Linker::new(&engine);
+    wasmtime_wasi::add_to_linker_sync(&mut linker)?;
+    let instance = linker.instantiate(&mut store, &component)?;
+    let skyforge = SkyforgeApi::new(&mut store, &instance)?;
 
-    plugin.instance = Some(instance);
+    plugin.instance = Some(skyforge);
+    info!("Plugin {} loaded successfully!", plugin.name);
 
     Ok(())
 }

--- a/src/wasm/plugins.rs
+++ b/src/wasm/plugins.rs
@@ -1,18 +1,17 @@
 use crate::init_plugin;
+use crate::SkyforgeApi;
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 use tokio::fs;
 use tracing::{debug, error};
-use wasmtime::Instance;
 
-#[derive(Clone, Debug)]
 pub struct WasmPlugin {
     pub name: String,
     pub path: PathBuf,
-    pub instance: Option<Instance>,
+    pub instance: Option<SkyforgeApi>,
 }
 
-pub async fn load_plugin<P: AsRef<Path>>(config_path: P, name: &str) -> Result<WasmPlugin> {
+pub async fn load_plugin(config_path: impl AsRef<Path>, name: &str) -> Result<WasmPlugin> {
     let plugins_path = config_path.as_ref().join("plugins");
     debug!("Loading plugins from {:?}", plugins_path);
 
@@ -25,27 +24,27 @@ pub async fn load_plugin<P: AsRef<Path>>(config_path: P, name: &str) -> Result<W
         anyhow::bail!("No plugins found in {:?}", &plugins_path,);
     }
 }
-async fn read_plugins(modules_path: PathBuf, plugin_name: &str) -> Result<WasmPlugin> {
+
+async fn read_plugins(modules_path: impl AsRef<Path>, plugin_name: &str) -> Result<WasmPlugin> {
     let mut dir = fs::read_dir(&modules_path).await?;
 
     while let Some(entry) = dir.next_entry().await? {
         let path = entry.path();
-        let file_name_opt = path.file_name().and_then(|os_str| os_str.to_str());
+        let file_name = path
+            .file_name()
+            .and_then(|os_str| os_str.to_str())
+            .ok_or(anyhow::anyhow!("Invalid file name for path: {:?}", path))?;
 
-        if let Some(file_name) = file_name_opt {
-            if file_name.ends_with(".wasm") {
-                if file_name.contains(plugin_name) {
-                    return Ok(WasmPlugin {
-                        name: file_name.to_string(),
-                        path,
-                        instance: None,
-                    });
-                }
-            }
+        if file_name.ends_with(".wasm") && file_name.contains(plugin_name) {
+            return Ok(WasmPlugin {
+                name: file_name.to_string(),
+                path,
+                instance: None,
+            });
         } else {
             error!("Invalid file name for path: {:?}", path);
         }
     }
 
-    return Err(anyhow::anyhow!("No plugin {plugin_name} found!"));
+    Err(anyhow::anyhow!("No plugin {plugin_name} found!"))
 }


### PR DESCRIPTION
Instead of using the dreaded get_typed_func, we switch to the component model which allows calling the plugins through the WIT interface as if it were a native function.

Signed-off-by: Victor Palade <victor@cloudflavor.io>