### PR TITLE
lib: fix WIT API file location.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,10 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y make gcc g++ libssl-dev pkg-config wget
+    - name: Clone Skyforge repo and copy wit API
+      run: |
+        git clone https://github.com/cloudflavor/skyforge.git 
+        rm wit || true && ln -s skyforge/spec/wit
     - name: Run clippy
       run: cargo clippy
     - name: Build skycrane

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ Cargo.lock
 
 *.wasm
 *.wat
-plugins-interface.json
+wit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2066,7 +2066,6 @@ version = "0.1.0"
 dependencies = [
  "allocative",
  "anyhow",
- "once_cell",
  "rust-embed",
  "starlark",
  "starlark_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 allocative = "0.3.3"
 anyhow = "1.0.79"
-once_cell = "1.19.0"
 rust-embed = { version = "8.2.0", features = ["interpolate-folder-path"] }
 starlark = "0.12.0"
 starlark_derive = "0.12.0"

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,7 @@ clippy:
 	@echo "Running clippy"
 	@cargo clippy --all-targets --all-features -- -D warnings
 
-get-spec:
-	@echo "Downloading spec"
-	@wget --quiet https://raw.githubusercontent.com/cloudflavor/skyforge/main/spec/plugins-interface.json -O spec/plugins-interface.json
-
-build: get-spec
+build:
 	@echo "Building binary"
 	@cargo build --release
 
@@ -31,7 +27,6 @@ clean:
 	@echo "Cleaning"
 	@cargo clean
 	@rm -rf target || true
-	@rm -rf spec/plugins-interface.json || true
 
 docs:
 	@echo "Building docs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 use structopt::StructOpt;
 
 bindgen!({
-    path: "../skyforge/spec/wit",
+    path: "wit",
 });
 
 #[derive(StructOpt, Clone, Debug)]


### PR DESCRIPTION
Set the location to a symlink instead of a relative path. Also the CI now clones the skyforge repo to build on the latest spec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Rust workflow configuration to clone Skyforge repository.
	- Cleaned up `.gitignore` to remove `plugins-interface.json` and added `wit`.

- **Refactor**
	- Removed `once_cell` dependency from `Cargo.toml`.
	- Simplified `Makefile` by removing the `get-spec` target.
	- Updated the path in `bindgen!` macro for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->