### PR TITLE
chore: remove hetzner config example.

### DIFF
--- a/examples/hetzner/base.star
+++ b/examples/hetzner/base.star
@@ -1,4 +1,0 @@
-module(
-    name = "hetzner",
-    version = "0.1.0",
-)


### PR DESCRIPTION
This is moved to the hetzner plugin in skyforge.