### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches: [ "main" ]
   workflow_dispatch:
+permissions:
+  contents: read
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/cloudflavor/skycrane/security/code-scanning/1](https://github.com/cloudflavor/skycrane/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow performs basic CI tasks (e.g., building, testing, and linting), it only requires `contents: read` permissions. Adding this block at the root level ensures all jobs in the workflow inherit these permissions unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
